### PR TITLE
簡単なカスタムオブジェクトをデプロイしてみる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ant-salesforce.jar
+retrieveOutput

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # migration-tool-playground
+
+## 準備
+
+環境変数をセットする。
+
+|環境変数名|説明|設定例|
+|----|----|----|
+|SALESFORCE_USERNAME|Force.comログイン名（メールアドレス）|aaa@test.net|
+|SALESFORCE_PASSWORD|Force.comログインパスワード + セキュリティトークン||

--- a/build.properties
+++ b/build.properties
@@ -6,7 +6,8 @@
 #sf.password = <Insert your Salesforce password here>
 #sf.pkgName = <Insert comma separated package names to be retrieved>
 #sf.zipFile = <Insert path of the zipfile to be retrieved>
-#sf.metadataType = <Insert metadata type name for which listMetadata or bulkRetrieve operations are to be performed>
+# metadata type name for which listMetadata or bulkRetrieve operations are to be performed
+sf.metadataType = CustomObject
 
 # Use 'https://login.salesforce.com' for production or developer edition (the default if not specified).
 # Use 'https://test.salesforce.com for sandbox.

--- a/build.properties
+++ b/build.properties
@@ -2,8 +2,8 @@
 #
 
 # Specify the login credentials for the desired Salesforce organization
-sf.username = <Insert your Salesforce username here>
-sf.password = <Insert your Salesforce password here>
+#sf.username = <Insert your Salesforce username here>
+#sf.password = <Insert your Salesforce password here>
 #sf.pkgName = <Insert comma separated package names to be retrieved>
 #sf.zipFile = <Insert path of the zipfile to be retrieved>
 #sf.metadataType = <Insert metadata type name for which listMetadata or bulkRetrieve operations are to be performed>

--- a/build.xml
+++ b/build.xml
@@ -1,4 +1,4 @@
-<project name="Sample usage of Salesforce Ant tasks" default="test" basedir="." xmlns:sf="antlib:com.salesforce">
+<project name="Sample usage of Salesforce Ant tasks" default="pkg1" basedir="." xmlns:sf="antlib:com.salesforce">
 
     <property file="build.properties"/>
     <property environment="env"/>

--- a/build.xml
+++ b/build.xml
@@ -16,7 +16,7 @@
     <target name="pkg1">
       <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" deployRoot="pkg1" rollbackOnError="true"/>
       <mkdir dir="retrieveOutput"/>
-      <sf:retrieve username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" retrieveTarget="retrieveOutput" packageNames="pkg1"/>
+      <sf:retrieve username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" retrieveTarget="retrieveOutput" packageNames="Pkg1"/>
     </target>
 
     <!-- Retrieve the information of all items of a particular metadata type -->

--- a/build.xml
+++ b/build.xml
@@ -9,79 +9,22 @@
         </classpath>
     </taskdef>
 
-    <!-- Test out deploy and retrieve verbs for package 'mypkg' -->
-    <target name="test">
-      <!-- Upload the contents of the "mypkg" package -->
-      <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" deployRoot="mypkg" rollbackOnError="true"/>
+    <!-- TODO: set value only if the property is empty -->
+    <property name="sf.username" value="${env.SALESFORCE_USERNAME}" />
+    <property name="sf.password" value="${env.SALESFORCE_PASSWORD}" />
+
+    <target name="pkg1">
+      <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" deployRoot="pkg1" rollbackOnError="true"/>
       <mkdir dir="retrieveOutput"/>
-      <!-- Retrieve the contents into another directory -->
-      <sf:retrieve username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" retrieveTarget="retrieveOutput" packageNames="MyPkg"/>
+      <sf:retrieve username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" retrieveTarget="retrieveOutput" packageNames="pkg1"/>
     </target>
 
-    <!-- Retrieve an unpackaged set of metadata from your org -->
-    <!-- The file unpackaged/package.xml lists what is to be retrieved -->
-    <target name="retrieveUnpackaged">
-      <mkdir dir="retrieveUnpackaged"/>
-      <!-- Retrieve the contents into another directory -->
-      <sf:retrieve username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" retrieveTarget="retrieveUnpackaged" unpackaged="unpackaged/package.xml"/>
-    </target>
-
-    <!-- Retrieve all the items of a particular metadata type -->
-    <target name="bulkRetrieve">
-      <sf:bulkRetrieve username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" metadataType="${sf.metadataType}" retrieveTarget="retrieveUnpackaged"/>
-    </target>
-
-    <!-- Retrieve metadata for all the packages specified under packageNames -->
-    <target name="retrievePkg">
-      <sf:retrieve username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" retrieveTarget="retrieveOutput" packageNames="${sf.pkgName}"/>
-    </target>
-
-    <!-- Deploy the unpackaged set of metadata retrieved with retrieveUnpackaged -->
-    <target name="deployUnpackaged">
-      <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" deployRoot="retrieveUnpackaged" rollbackOnError="true"/>
-    </target>
-
-    <!-- Deploy a zip of metadata files to the org -->
-    <target name="deployZip">
-      <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" zipFile="${sf.zipFile}" pollWaitMillis="1000" rollbackOnError="true"/>
-    </target>
-
-    <!-- Shows deploying code & running tests for code in directory -->
-    <target name="deployCode">
-      <!-- Upload the contents of the "codepkg" directory, running the tests for just 1 class -->
-      <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" deployRoot="codepkg" rollbackOnError="true">
-        <runTest>SampleDeployClass</runTest>
-      </sf:deploy>
-    </target>
-
-    <!-- Shows removing code; only succeeds if done after deployCode -->
-    <target name="undeployCode">
-      <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" deployRoot="removecodepkg"/>
-    </target>
-
-    <!-- Shows retrieving code; only succeeds if done after deployCode -->
-    <target name="retrieveCode">
-      <!-- Retrieve the contents listed in the file codepkg/package.xml into the codepkg directory -->
-      <sf:retrieve username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" retrieveTarget="codepkg" unpackaged="codepkg/package.xml"/>
-    </target>
-
-    <!-- Shows deploying code, running all tests, and running tests (1 of which fails), and logging. -->
-    <target name="deployCodeFailingTest">
-      <!-- Upload the contents of the "codepkg" package, running all tests -->
-      <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" deployRoot="codepkg" runAllTests="true" rollbackOnError="true" logType="Debugonly"/>
-    </target>
-
-    <!-- Shows check only; never actually saves to the server -->
-    <target name="deployCodeCheckOnly">
-      <sf:deploy username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" maxPoll="${sf.maxPoll}" deployRoot="codepkg" checkOnly="true"/>
-    </target>
-
-	<!-- Retrieve the information of all items of a particular metadata type -->
+    <!-- Retrieve the information of all items of a particular metadata type -->
     <target name="listMetadata">
       <sf:listMetadata username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}" metadataType="${sf.metadataType}"/>
     </target>
 
-	<!-- Retrieve the information on all supported metadata type -->
+    <!-- Retrieve the information on all supported metadata type -->
     <target name="describeMetadata">
       <sf:describeMetadata username="${sf.username}" password="${sf.password}" serverurl="${sf.serverurl}"/>
     </target>

--- a/pkg1/objects/Hoge__c.object
+++ b/pkg1/objects/Hoge__c.object
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <deploymentStatus>Deployed</deploymentStatus>
+    <label>ほげ</label>
+    <nameField>
+        <label>ほげ名</label>
+        <type>Text</type>
+    </nameField>
+    <pluralLabel>hoges</pluralLabel>
+    <sharingModel>ReadWrite</sharingModel>
+</CustomObject>

--- a/pkg1/package.xml
+++ b/pkg1/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Pkg1</fullName>
+    <types>
+        <members>Hoge__c</members>
+        <name>CustomObject</name>
+    </types>
+    <version>33.0</version>
+</Package>


### PR DESCRIPTION
# 目的

- 移行ツールの動作確認のため、簡単なカスタムオブジェクトをデプロイして、Force.com上で作成されていることを確認する。

# 備考

- `build.properties`, `build.xml` 中にForce.comのユーザ名、パスワードを書くのはNGなので、環境変数を利用する。